### PR TITLE
fix: serialize Create to prevent zip cross-contamination under parallel apply

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## v0.12.0
+
+Serialize `Create` so parallel builds of multiple `lambdazip_file` resources no longer produce zips with the wrong contents.

--- a/internal/provider/file_resource.go
+++ b/internal/provider/file_resource.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/int32validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
@@ -30,6 +31,14 @@ import (
 )
 
 var _ resource.ResourceWithConfigValidators = &FileResource{}
+
+// chdirMu guards the process-wide working directory. Terraform runs a single
+// provider instance's operations concurrently in one process, so without this
+// lock concurrent builds race on cwd and produce cross-contaminated zips.
+// Create mutates cwd via os.Chdir and takes the write lock; operations that
+// only read cwd-relative paths (the files_sha256 data source) take the read
+// lock so they cannot observe a directory a concurrent Create has chdir'd into.
+var chdirMu sync.RWMutex
 
 func NewFileResource() resource.Resource {
 	return &FileResource{}
@@ -181,107 +190,136 @@ func (r *FileResource) Create(ctx context.Context, req resource.CreateRequest, r
 	useTempDir := plan.UseTempDir.ValueBool()
 	compressionLevel := int(plan.CompressionLevel.ValueInt32())
 	stripComponents := int(plan.StripComponents.ValueInt32())
-	cwd, err := os.Getwd()
 
-	if err != nil {
-		resp.Diagnostics.AddError("Failed to get current directory", err.Error())
-		return
-	}
+	// Build the zip under a lock. Everything in here depends on the process-wide
+	// working directory (os.Getwd, os.Chdir, cwd-relative glob and file reads),
+	// so it must not run concurrently with another resource's build. os.Getwd is
+	// read inside the lock so no other goroutine has chdir'd away, and the cwd is
+	// restored by deferred os.Chdir before the lock is released. Hashing and
+	// state writes below use the absolute output path and stay outside the lock.
+	func() {
+		chdirMu.Lock()
+		defer chdirMu.Unlock()
 
-	if !strings.HasPrefix(output, "/") {
-		output = filepath.Join(cwd, output)
-	}
-
-	if baseDir != "" {
-		err = os.Chdir(baseDir)
+		cwd, err := os.Getwd()
 
 		if err != nil {
-			resp.Diagnostics.AddError("Failed to change current working directory", err.Error())
+			resp.Diagnostics.AddError("Failed to get current directory", err.Error())
 			return
 		}
 
-		defer os.Chdir(cwd) //nolint:errcheck
-	}
-
-	if useTempDir {
-		tempDir, err := os.MkdirTemp("", "lambdazip")
-
-		if err != nil {
-			resp.Diagnostics.AddError("Failed to create temporary directory", err.Error())
-			return
+		// Restore cwd before the lock is released. A failed restore would leave
+		// the process in the wrong directory and break later operations, so it
+		// is reported instead of ignored.
+		restoreCwd := func() {
+			if err := os.Chdir(cwd); err != nil {
+				resp.Diagnostics.AddError("Failed to restore current working directory", err.Error())
+			}
 		}
 
-		defer os.RemoveAll(tempDir)
-		err = cp.Copy(".", tempDir)
-
-		if err != nil {
-			resp.Diagnostics.AddError("Failed to copy files to temporary directory", err.Error())
-			return
+		if !filepath.IsAbs(output) {
+			output = filepath.Join(cwd, output)
 		}
 
-		err = os.Chdir(tempDir)
-
-		if err != nil {
-			resp.Diagnostics.AddError("Failed to change current working directory", err.Error())
-			return
-		}
-
-		defer os.Chdir(cwd) //nolint:errcheck
-	}
-
-	sources := []string{}
-
-	if len(plan.Sources) >= 1 {
-		for _, pat := range plan.Sources {
-			sources = append(sources, pat.ValueString())
-		}
-
-		excludes := []string{}
-
-		for _, pat := range plan.Excludes {
-			excludes = append(excludes, pat.ValueString())
-		}
-
-		if beforeCreate := plan.BeforeCreate.ValueString(); beforeCreate != "" {
-			cmdout, err := cmd.Run(beforeCreate)
+		if baseDir != "" {
+			err = os.Chdir(baseDir)
 
 			if err != nil {
-				cmdout = strings.TrimSpace(cmdout)
+				resp.Diagnostics.AddError("Failed to change current working directory", err.Error())
+				return
+			}
 
-				if cmdout == "" {
-					cmdout = "(empty)"
+			defer restoreCwd()
+		}
+
+		if useTempDir {
+			tempDir, err := os.MkdirTemp("", "lambdazip")
+
+			if err != nil {
+				resp.Diagnostics.AddError("Failed to create temporary directory", err.Error())
+				return
+			}
+
+			defer os.RemoveAll(tempDir)
+			err = cp.Copy(".", tempDir)
+
+			if err != nil {
+				resp.Diagnostics.AddError("Failed to copy files to temporary directory", err.Error())
+				return
+			}
+
+			err = os.Chdir(tempDir)
+
+			if err != nil {
+				resp.Diagnostics.AddError("Failed to change current working directory", err.Error())
+				return
+			}
+
+			defer restoreCwd()
+		}
+
+		sources := []string{}
+
+		if len(plan.Sources) >= 1 {
+			for _, pat := range plan.Sources {
+				sources = append(sources, pat.ValueString())
+			}
+
+			excludes := []string{}
+
+			for _, pat := range plan.Excludes {
+				excludes = append(excludes, pat.ValueString())
+			}
+
+			if beforeCreate := plan.BeforeCreate.ValueString(); beforeCreate != "" {
+				cmdout, err := cmd.Run(beforeCreate)
+
+				if err != nil {
+					cmdout = strings.TrimSpace(cmdout)
+
+					if cmdout == "" {
+						cmdout = "(empty)"
+					}
+
+					summary := fmt.Sprintf("Failed to run `%s`", beforeCreate)
+					detail := fmt.Sprintf("%s\noutput: %s", err, cmdout)
+					resp.Diagnostics.AddError(summary, detail)
+					return
 				}
+			}
 
-				summary := fmt.Sprintf("Failed to run `%s`", beforeCreate)
-				detail := fmt.Sprintf("%s\noutput: %s", err, cmdout)
-				resp.Diagnostics.AddError(summary, detail)
+			sources, err = glob.Glob(sources, excludes)
+
+			if err != nil {
+				resp.Diagnostics.AddError("Failed to glob files", err.Error())
 				return
 			}
 		}
 
-		sources, err = glob.Glob(sources, excludes)
+		contents := map[string]string{}
+
+		if len(plan.Contents.Elements()) >= 1 {
+			elements := make(map[string]types.String, len(plan.Contents.Elements()))
+			resp.Diagnostics.Append(plan.Contents.ElementsAs(ctx, &elements, false)...)
+
+			if resp.Diagnostics.HasError() {
+				return
+			}
+
+			for name, data := range elements {
+				contents[name] = data.ValueString()
+			}
+		}
+
+		err = zip.ZipFile(sources, contents, output, compressionLevel, stripComponents)
 
 		if err != nil {
-			resp.Diagnostics.AddError("Failed to glob files", err.Error())
+			resp.Diagnostics.AddError("Failed to zip files", err.Error())
 			return
 		}
-	}
+	}()
 
-	contents := map[string]string{}
-
-	if len(plan.Contents.Elements()) >= 1 {
-		elements := make(map[string]types.String, len(plan.Contents.Elements()))
-		plan.Contents.ElementsAs(ctx, &elements, false)
-
-		for name, data := range elements {
-			contents[name] = data.ValueString()
-		}
-	}
-
-	err = zip.ZipFile(sources, contents, output, compressionLevel, stripComponents)
-
-	if err != nil {
-		resp.Diagnostics.AddError("Failed to zip files", err.Error())
+	if resp.Diagnostics.HasError() {
 		return
 	}
 

--- a/internal/provider/file_resource_test.go
+++ b/internal/provider/file_resource_test.go
@@ -743,3 +743,66 @@ func TestContents_removePrefix(t *testing.T) {
 		},
 	})
 }
+
+// TestFiles_concurrent creates two lambdazip_file resources with different
+// base_dir values in a single apply, which Terraform builds concurrently. It
+// guards against the cwd race where parallel builds produced zips with the
+// wrong contents. With the serialization in place each zip contains only its
+// own files.
+func TestFiles_concurrent(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	cwd, _ := os.Getwd()
+	os.Chdir(t.TempDir())
+	defer os.Chdir(cwd)
+
+	os.Mkdir("a", 0755)
+	os.WriteFile("a/a1.txt", []byte("a1"), 0644)
+	os.WriteFile("a/a2.txt", []byte("a2"), 0644)
+	os.Mkdir("b", 0755)
+	os.WriteFile("b/b1.txt", []byte("b1"), 0644)
+	os.WriteFile("b/b2.txt", []byte("b2"), 0644)
+
+	resource.Test(t, resource.TestCase{
+		IsUnitTest:               true,
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: `
+					resource "lambdazip_file" "a" {
+						base_dir      = "a"
+						sources       = ["**/*.txt"]
+						output        = "a.zip"
+						before_create = "sleep 1"
+						use_temp_dir  = true
+					}
+
+					resource "lambdazip_file" "b" {
+						base_dir      = "b"
+						sources       = ["**/*.txt"]
+						output        = "b.zip"
+						before_create = "sleep 1"
+						use_temp_dir  = true
+					}
+				`,
+				Check: resource.ComposeTestCheckFunc(
+					func(*terraform.State) error {
+						bufA, err := os.ReadFile("a.zip")
+						require.NoError(err)
+						listA, err := listZip(bufA)
+						require.NoError(err)
+						assert.Equal([]string{"a1.txt", "a2.txt"}, listA)
+
+						bufB, err := os.ReadFile("b.zip")
+						require.NoError(err)
+						listB, err := listZip(bufB)
+						require.NoError(err)
+						assert.Equal([]string{"b1.txt", "b2.txt"}, listB)
+						return nil
+					},
+				),
+			},
+		},
+	})
+}

--- a/internal/provider/files_sha256_data_source.go
+++ b/internal/provider/files_sha256_data_source.go
@@ -118,17 +118,28 @@ func (d *FilesSha256DataSource) Read(ctx context.Context, req datasource.ReadReq
 			globOpts = append(globOpts, doublestar.WithFailOnPatternNotExist())
 		}
 
-		files, err := glob.Glob(files, excludes, globOpts...)
+		// glob and hashing read cwd-relative paths, so they must not run while a
+		// resource Create has chdir'd elsewhere. Share chdirMu as a reader.
+		func() {
+			chdirMu.RLock()
+			defer chdirMu.RUnlock()
 
-		if err != nil {
-			resp.Diagnostics.AddError("Failed to glob files", err.Error())
-			return
-		}
+			globbed, err := glob.Glob(files, excludes, globOpts...)
 
-		mFiles, err = hash.Sha256Map(files)
+			if err != nil {
+				resp.Diagnostics.AddError("Failed to glob files", err.Error())
+				return
+			}
 
-		if err != nil {
-			resp.Diagnostics.AddError("Failed to calculate sha256sum", err.Error())
+			mFiles, err = hash.Sha256Map(globbed)
+
+			if err != nil {
+				resp.Diagnostics.AddError("Failed to calculate sha256sum", err.Error())
+				return
+			}
+		}()
+
+		if resp.Diagnostics.HasError() {
 			return
 		}
 	}
@@ -137,7 +148,12 @@ func (d *FilesSha256DataSource) Read(ctx context.Context, req datasource.ReadReq
 
 	if len(data.Contents.Elements()) >= 1 {
 		elements := make(map[string]types.String, len(data.Contents.Elements()))
-		data.Contents.ElementsAs(ctx, &elements, false)
+		resp.Diagnostics.Append(data.Contents.ElementsAs(ctx, &elements, false)...)
+
+		if resp.Diagnostics.HasError() {
+			return
+		}
+
 		dataByName := map[string]string{}
 
 		for name, data := range elements {


### PR DESCRIPTION
Building two or more `lambdazip_file` resources in one apply could produce zip files containing the wrong files. The cause is `os.Chdir` in `Create`. It changes the working directory for the whole process, and Terraform runs a provider's resource operations concurrently in a single process, so two parallel `Create` calls could interleave their directory changes and glob, and both would collect files from the same directory. With `use_temp_dir = true` the resource still calls `os.Chdir`, so it did not help.

This serializes the working-directory-sensitive part of `Create` with a package-level mutex. The lock is taken before the first `os.Chdir` and released after the working directory is restored, so concurrent builds no longer race on it. Resources running in separate provider processes are unaffected because they do not share a working directory.

The previous workarounds, `depends_on` between resources or `-parallelism=1`, remain valid but are no longer required.

`go build`, `go vet`, `go test ./internal/provider`, and `golangci-lint run` all pass.