### PR TITLE
Update lambdazip provider version to 0.12

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ terraform {
   required_providers {
     lambdazip = {
       source  = "winebarrel/lambdazip"
-      version = ">= 0.11"
+      version = ">= 0.12"
     }
   }
 }


### PR DESCRIPTION
This pull request updates the required version of the `lambdazip` Terraform provider in the `README.md` file to ensure compatibility with newer features and bug fixes.

Dependency version update:

* Increased the minimum required version of the `lambdazip` provider from `0.11` to `0.12` in the `terraform` block of `README.md`.